### PR TITLE
Rewind stdin before reading from it

### DIFF
--- a/apdu_fuzzer/main_afl.py
+++ b/apdu_fuzzer/main_afl.py
@@ -332,6 +332,7 @@ def client_fuzzer(fd, lfd, args=None, **kwargs):
         # s = csock()  # Pre-fork connection. needs more sophisticated reconnect if socket is broken.
         while afl.loop(3):
             sys.settrace(None)
+            stdin_compat.seek(0)
             buffer = stdin_compat.read()
             buffer = tpler.transform(buffer)
             if buffer is None:


### PR DESCRIPTION
Rewinding stdin is necessary for persistent mode in [Python 2](https://docs.python.org/2/library/stdtypes.html#file.read), because the underlying C stdio can cache the EOF status. This happens at least on [FreeBSD](https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=108118) and OS X.

(This is 100% untested. Sorry!)