### PR TITLE
Clarifying installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,12 @@ brew install pcsc-lite
 pip install llsmartcard-ph4
 ```
 
+We as well need modified version of [python-afl-ph4]
+
+```
+pip install git+https://github.com/ph4r05/python-afl
+```
+
 ## Experimental installation with pip
 
 ```
@@ -165,10 +171,12 @@ echo -n '0000' | ../venv/bin/python main_afl.py --client --output ydat.json --lo
 cat ylog.txt
 ```
 
+(Note: this check does not work on macOS, due to the fact that client performs `stdin_compat.seek(0)`  but unnamed pipes are not seekable on macOS)
+
 AFL with forking & TCP communication with the server:
 
 ```
-../venv/bin/py-afl-fuzz -m 500 -t 5000 -o result/ -i inputs/ -- ../venv/bin/python main_afl.py --client --output ydat.json --log ylog.txt
+../venv/bin/py-afl-fuzz -m 500 -t 5000 -o result/ -i inputs/ -- ../venv/bin/python main_afl.py --client --output ydat.json --log ylog.txt --payload-len 4
 ```
 
 ## Local development

--- a/apdu_fuzzer/main_afl.py
+++ b/apdu_fuzzer/main_afl.py
@@ -112,9 +112,9 @@ def llog(fd=None, msg=None):
     fd.flush()
 
 
-def gen_input(len=4):
-    with open('inputs/zeros_%04d.bin' % len, 'wb') as fh:
-        fh.write(bytes([0]*len))
+def gen_input(length=4):
+    with open('inputs/zeros_%04d.bin' % length, 'wb') as fh:
+        fh.write(bytes([0]*length))
 
 
 def purge_inputs():
@@ -230,7 +230,7 @@ class Templater(object):
         self.sample_len = self.inp_len
         self.inp_len_b = self.inp_len or 0
         self.inp_len_s = self.inp_len or 0
-        self.gen_h_len = None
+        self.gen_h_len = 0
         self.tpl_b = None
         self.mask_b = None
 


### PR DESCRIPTION
Changes:

- Readme points to _modified_ version of `python-afl`, which is **necessary** to successfully run fuzzer
- fixed type error causing fuzzer to crash with default settings
- added missing parameter to example code
- clarified macOS behaviour