### PR TITLE
Report timing in nanoseconds rather than in seconds

### DIFF
--- a/apdu_fuzzer/utils/card_interactor.py
+++ b/apdu_fuzzer/utils/card_interactor.py
@@ -69,9 +69,9 @@ class CardInteractor:
         debug("card.interactor", stri)
         try:
 
-            start = time.time()
+            start = time.time_ns()
             (data, sw1, sw2) = self.card._send_apdu(data)
-            end = time.time()
+            end = time.time_ns()
             timing = end - start
         except SWException as e:
             # Did we get an unsuccessful attempt?


### PR DESCRIPTION
The `CardInteractor` measures and reports the timing of the send APDU in seconds with `time.time()`. This results in a timing value of ~0s for the majority of fast APDU instructions.